### PR TITLE
Add FPS overlay in debug mode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,18 @@ cargo build --release
 # Binary at target/release/hypruler
 ```
 
+## Development
+
+### FPS overlay
+
+For profiling frame timing, build with the `release-debug` profile and set `HYPRULER_DEBUG=1`:
+
+```bash
+just build-debug && just start-debug
+```
+
+This renders an on-screen FPS counter via `src/fps.rs` (EMA-smoothed). The overlay is gated by both `cfg!(debug_assertions)` and the env var, so release builds never include it.
+
 ## Dependencies
 
 - `smithay-client-toolkit` - Wayland client library with layer-shell support

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,9 @@ memmap2 = "0.9"
 rustix = { version = "1.0", features = ["fs", "shm"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+
+# Release optimizations + debug_assertions, so HYPRULER_DEBUG=1 enables the FPS overlay
+# under realistic performance. Build with `cargo build --profile release-debug`.
+[profile.release-debug]
+inherits = "release"
+debug-assertions = true

--- a/justfile
+++ b/justfile
@@ -4,8 +4,14 @@ dev:
 build:
   cargo build --release
 
+build-debug:
+  cargo build --profile release-debug
+
 start:
   ./target/release/hypruler
+
+start-debug:
+  HYPRULER_DEBUG=1 ./target/release-debug/hypruler
 
 install:
   cargo install --path .

--- a/src/fps.rs
+++ b/src/fps.rs
@@ -1,0 +1,46 @@
+use std::time::Instant;
+
+/// EMA-smoothed FPS counter. Active only when `HYPRULER_DEBUG=1` in a debug build.
+pub struct FrameClock {
+    last: Option<Instant>,
+    smoothed_fps: f64,
+}
+
+impl FrameClock {
+    fn new() -> Self {
+        Self {
+            last: None,
+            smoothed_fps: 0.0,
+        }
+    }
+
+    /// Record a frame. Returns `(dt_ms, instantaneous_fps)` if a previous tick exists.
+    pub fn tick(&mut self) -> Option<(f64, f64)> {
+        let now = Instant::now();
+        let result = self.last.map(|prev| {
+            let dt_ms = now.duration_since(prev).as_secs_f64() * 1000.0;
+            let inst_fps = if dt_ms > 0.0 { 1000.0 / dt_ms } else { 0.0 };
+            let alpha = 0.1;
+            self.smoothed_fps = if self.smoothed_fps == 0.0 {
+                inst_fps
+            } else {
+                alpha * inst_fps + (1.0 - alpha) * self.smoothed_fps
+            };
+            (dt_ms, inst_fps)
+        });
+        self.last = Some(now);
+        result
+    }
+
+    pub fn fps(&self) -> f64 {
+        self.smoothed_fps
+    }
+}
+
+pub fn debug_clock_if_enabled() -> Option<FrameClock> {
+    if cfg!(debug_assertions) && std::env::var("HYPRULER_DEBUG").is_ok() {
+        Some(FrameClock::new())
+    } else {
+        None
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 mod capture;
 mod edge_detection;
+mod fps;
 mod ui;
 mod wayland_handlers;
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -41,6 +41,10 @@ fn label_bg_color() -> Color {
     Color::from_rgba8(40, 40, 40, 230)
 }
 
+pub fn text_color_white() -> Color {
+    Color::from_rgba8(255, 255, 255, 255)
+}
+
 fn stroke_line(
     pixmap: &mut Pixmap,
     paint: &Paint,
@@ -103,6 +107,7 @@ pub fn draw_measurements(
         lx,
         ly,
         font,
+        text_color_white(),
     );
 }
 
@@ -180,7 +185,14 @@ pub fn draw_rectangle_measurement(
         };
         (center_x, y)
     };
-    draw_label(pixmap, &format!("{} x {}", width, height), lx, ly, font);
+    draw_label(
+        pixmap,
+        &format!("{} x {}", width, height),
+        lx,
+        ly,
+        font,
+        text_color_white(),
+    );
 }
 
 fn draw_end_cap(
@@ -257,21 +269,36 @@ fn draw_rounded_rect(pixmap: &mut Pixmap, x: f32, y: f32, width: f32, height: f3
     }
 }
 
-fn blend_pixel(pixel: &PremultipliedColorU8, alpha: f32) -> Option<PremultipliedColorU8> {
+fn blend_pixel(
+    pixel: &PremultipliedColorU8,
+    alpha: f32,
+    text_rgb: (u8, u8, u8),
+) -> Option<PremultipliedColorU8> {
     let inv_a = 1.0 - alpha;
     let max_val = pixel.alpha() as f32;
+    let (tr, tg, tb) = text_rgb;
     PremultipliedColorU8::from_rgba(
-        ((inv_a * pixel.red() as f32 + alpha * 255.0).min(max_val)) as u8,
-        ((inv_a * pixel.green() as f32 + alpha * 255.0).min(max_val)) as u8,
-        ((inv_a * pixel.blue() as f32 + alpha * 255.0).min(max_val)) as u8,
+        ((inv_a * pixel.red() as f32 + alpha * tr as f32).min(max_val)) as u8,
+        ((inv_a * pixel.green() as f32 + alpha * tg as f32).min(max_val)) as u8,
+        ((inv_a * pixel.blue() as f32 + alpha * tb as f32).min(max_val)) as u8,
         (inv_a * pixel.alpha() as f32 + alpha * 255.0) as u8,
     )
 }
 
-fn draw_text(pixmap: &mut Pixmap, font: &fontdue::Font, text: &str, start_x: f32, baseline_y: f32) {
+fn draw_text(
+    pixmap: &mut Pixmap,
+    font: &fontdue::Font,
+    text: &str,
+    start_x: f32,
+    baseline_y: f32,
+    color: Color,
+) {
     let (width, height) = (pixmap.width() as i32, pixmap.height() as i32);
     let stride = width as usize;
     let pixels = pixmap.pixels_mut();
+
+    let c8 = color.to_color_u8();
+    let text_rgb = (c8.red(), c8.green(), c8.blue());
 
     let mut cursor_x = start_x;
     for c in text.chars() {
@@ -292,7 +319,7 @@ fn draw_text(pixmap: &mut Pixmap, font: &fontdue::Font, text: &str, start_x: f32
                 }
 
                 let idx = draw_y as usize * stride + draw_x as usize;
-                if let Some(new_pixel) = blend_pixel(&pixels[idx], alpha as f32 / 255.0) {
+                if let Some(new_pixel) = blend_pixel(&pixels[idx], alpha as f32 / 255.0, text_rgb) {
                     pixels[idx] = new_pixel;
                 }
             }
@@ -307,6 +334,7 @@ pub(crate) fn draw_label(
     x: f32,
     y: f32,
     font: Option<&fontdue::Font>,
+    text_color: Color,
 ) {
     let mut text_width = 0.0;
     if let Some(font) = font {
@@ -332,6 +360,6 @@ pub(crate) fn draw_label(
     if let Some(font) = font {
         let text_x = label_x + LABEL_PADDING.0;
         let baseline_y = label_y + LABEL_PADDING.1 + FONT_SIZE * 0.8;
-        draw_text(pixmap, font, text, text_x, baseline_y);
+        draw_text(pixmap, font, text, text_x, baseline_y, text_color);
     }
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -301,7 +301,13 @@ fn draw_text(pixmap: &mut Pixmap, font: &fontdue::Font, text: &str, start_x: f32
     }
 }
 
-fn draw_label(pixmap: &mut Pixmap, text: &str, x: f32, y: f32, font: Option<&fontdue::Font>) {
+pub(crate) fn draw_label(
+    pixmap: &mut Pixmap,
+    text: &str,
+    x: f32,
+    y: f32,
+    font: Option<&fontdue::Font>,
+) {
     let mut text_width = 0.0;
     if let Some(font) = font {
         for c in text.chars() {

--- a/src/wayland_handlers.rs
+++ b/src/wayland_handlers.rs
@@ -1,6 +1,7 @@
 use crate::capture::Screenshot;
 use crate::edge_detection::{find_edges, snap_edge_x, snap_edge_y};
-use crate::ui::{draw_crosshair, draw_measurements, draw_rectangle_measurement};
+use crate::fps::{FrameClock, debug_clock_if_enabled};
+use crate::ui::{draw_crosshair, draw_label, draw_measurements, draw_rectangle_measurement};
 use std::process::Command;
 
 use smithay_client_toolkit::{
@@ -92,6 +93,9 @@ pub struct WaylandApp {
     drag_rect: Option<(u32, u32, u32, u32)>,
     is_dragging: bool,
 
+    // Debug FPS overlay (None unless HYPRULER_DEBUG=1 in a debug build)
+    debug_clock: Option<FrameClock>,
+
     // Control
     exit: bool,
 }
@@ -158,6 +162,7 @@ impl WaylandApp {
             drag_start: None,
             drag_rect: None,
             is_dragging: false,
+            debug_clock: debug_clock_if_enabled(),
             exit: false,
         };
 
@@ -299,6 +304,19 @@ impl WaylandApp {
                 self.scale,
             );
             draw_crosshair(pixmap, cursor_phys_x as f32, cursor_phys_y as f32);
+        }
+
+        if let Some(clock) = self.debug_clock.as_mut() {
+            if let Some((dt_ms, inst_fps)) = clock.tick() {
+                eprintln!("[hypruler-debug] dt={dt_ms:.2}ms fps={inst_fps:.1}");
+            }
+            draw_label(
+                pixmap,
+                &format!("FPS: {:.1}", clock.fps()),
+                80.0,
+                30.0,
+                self.font.as_ref(),
+            );
         }
 
         // Composite overlay onto canvas

--- a/src/wayland_handlers.rs
+++ b/src/wayland_handlers.rs
@@ -2,6 +2,7 @@ use crate::capture::Screenshot;
 use crate::edge_detection::{find_edges, snap_edge_x, snap_edge_y};
 use crate::fps::{FrameClock, debug_clock_if_enabled};
 use crate::ui::{draw_crosshair, draw_label, draw_measurements, draw_rectangle_measurement};
+use tiny_skia::Color;
 use std::process::Command;
 
 use smithay_client_toolkit::{
@@ -310,12 +311,21 @@ impl WaylandApp {
             if let Some((dt_ms, inst_fps)) = clock.tick() {
                 eprintln!("[hypruler-debug] dt={dt_ms:.2}ms fps={inst_fps:.1}");
             }
+            let fps = clock.fps();
+            let color = if fps >= 55.0 {
+                Color::from_rgba8(46, 204, 113, 255) // green
+            } else if fps >= 30.0 {
+                Color::from_rgba8(243, 156, 18, 255) // yellow/orange
+            } else {
+                Color::from_rgba8(231, 76, 60, 255) // red
+            };
             draw_label(
                 pixmap,
-                &format!("FPS: {:.1}", clock.fps()),
+                &format!("FPS: {:.1}", fps),
                 80.0,
                 30.0,
                 self.font.as_ref(),
+                color,
             );
         }
 


### PR DESCRIPTION
This makes it easier to test the performance of the app and catch regressions in the FPS rate.

```bash
just build-debug
just start-debug
```

You should now see the FPS overlay in the top left corner of your screen while hypruler is active!

<img width="346" height="236" alt="image" src="https://github.com/user-attachments/assets/cccdbad8-204e-4383-a3c0-47f617b96272" />
